### PR TITLE
Update PID controller on every entity change

### DIFF
--- a/custom_components/pid_controller/sensor.py
+++ b/custom_components/pid_controller/sensor.py
@@ -797,8 +797,7 @@ class PidController(SensorEntity):
                 self.reset_pid()
                 self._pid.set_point = set_point
 
-            if entity == self._source:
-                self._pid.update(source)
+            self._pid.update(source)
 
             output = float(self._pid.output)
 


### PR DESCRIPTION
This updates the PID controller whenever any entity state change occurs. To stabilize this, sample_time must be set. This approach only works, when enough entity changes occur in home-assistant but the approach is still better than the current implementation.
partially fixes #45 